### PR TITLE
Feature/ab#1767 make positionsource read nmea sentences from command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ This code employs pydantic-settings for configuration handling. On startup, the 
 
 The `settings.template.yaml` should always reflect a correct and fully fledged settings structure to use as a starting point for users.
 
+## Test GPS reader
+- Make sure you have `gpsd` and `gpsd-clients` installed in your system
+- Run `gpsfake -P 2948 -c 0.1 test_gps.log` (this will start gpsd on port 2948 and feed it the log file lines in 100ms intervals)
+- Use `["gpspipe", "-r, "localhost:2948"]` in your `settings.yaml`
+
 ## Github Workflows and Versioning
 
 The following Github Actions are available:

--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ This code employs pydantic-settings for configuration handling. On startup, the 
 
 The `settings.template.yaml` should always reflect a correct and fully fledged settings structure to use as a starting point for users.
 
-## Test GPS reader
-- Make sure you have `gpsd` and `gpsd-clients` installed in your system
-- Run `gpsfake -P 2948 -c 0.1 test_gps.log` (this will start gpsd on port 2948 and feed it the log file lines in 100ms intervals)
-- Use `["gpspipe", "-r, "localhost:2948"]` in your `settings.yaml`
+## Test GPS command reader
+- Use `["bash", "-c", "while IFS= read -r line; do echo \"$line\" | cut -d';' -f2-; sleep 0.1; done < test.log"]` as a command in your `settings.yaml` to feed a log file (with timestamps; remove the cut command if your log file contains just NMEA sentences) in 100ms intervals to the position source
 
 ## Github Workflows and Versioning
 

--- a/positionsource/commandreader.py
+++ b/positionsource/commandreader.py
@@ -1,0 +1,90 @@
+import logging
+import os
+import subprocess
+import time
+from threading import Event, Lock, Thread
+from typing import List, Optional
+
+from pynmeagps import NMEAMessage, NMEAReader
+
+from .datatypes import GpsPosition
+
+logger = logging.getLogger(__name__)
+
+class CommandGpsError(Exception):
+    pass
+
+class CommandGpsReader:
+    '''This class reads GPS data from a serial device and provides the latest position. It uses a separate thread to read data continuously.
+        It needs to be closed properly to release the serial port.'''
+    def __init__(self, command: List[str]):
+        self._stop_event = Event()
+        self._current_position: GpsPosition = None
+        self._read_thread: Thread = Thread(target=self._gps_read_loop, kwargs={'command': command, 'stop_event': self._stop_event}, daemon=True)
+        self._last_position_lock = Lock()
+        self._read_thread.start()
+
+    def _gps_read_loop(self, command: List[str], stop_event: Event):
+        '''This method runs in a separate thread. Do not call it directly.'''
+        try:
+            proc = None
+            while not stop_event.is_set():
+                if proc is None:
+                    proc = subprocess.Popen(args=command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    # We don't want to block on stderr reads
+                    os.set_blocking(proc.stderr.fileno(), False)
+                    logger.debug(f'Started gps reader subprocess with command {" ".join(command)}')
+                    time.sleep(0.5)
+
+                # Check if the started process is still alive
+                if (ret_code := proc.poll()) is not None:
+                    logger.warning(f'Subprocess has ended with code {ret_code}. Restarting...)')
+                    self._log_multiline_output(proc.stderr.readlines(), 'stderr', logging.WARNING)
+                    proc = None
+                    time.sleep(1)
+                    continue
+
+                # Retrieve stderr output (to make sure the buffer does not fill up) and display for informational purposes
+                stderr_lines = proc.stderr.readlines()
+                if len(stderr_lines) > 0:
+                    self._log_multiline_output(stderr_lines, 'stderr', logging.WARNING)
+
+                line = proc.stdout.readline()
+                if not line.startswith(b'$'):
+                    continue
+
+                nmea: NMEAMessage = NMEAReader.parse(line)
+                if nmea.msgID != 'GGA':
+                    continue
+
+                new_position = GpsPosition(
+                    fix=nmea.quality == 1,
+                    lat=nmea.lat if nmea.lat != '' else 0,
+                    lon=nmea.lon if nmea.lon != '' else 0,
+                    hdop=nmea.HDOP if nmea.HDOP != '' else 0,
+                    timestamp_utc_ms=int(time.time() * 1000)
+                )
+                with self._last_position_lock:
+                    self._current_position = new_position
+
+        except subprocess.SubprocessError as e:
+            raise CommandGpsError(f"Subprocess error: {e}")
+        
+    def _log_multiline_output(self, lines: List[bytes], prefix: str, log_level: int) -> None:
+        for line in lines:
+            logger.log(log_level, f'{prefix}: {line.decode().strip()}')
+
+    @property
+    def position(self) -> Optional[GpsPosition]:
+        with self._last_position_lock:
+            return self._current_position
+        
+    @property
+    def is_alive(self) -> bool:
+        return self._read_thread.is_alive()
+
+    def close(self):
+        self._stop_event.set()
+        self._read_thread.join(timeout=2)
+        if self._read_thread.is_alive():
+            raise CommandGpsError('Could not stop reader thread.')

--- a/positionsource/config.py
+++ b/positionsource/config.py
@@ -1,6 +1,5 @@
-
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal, Union, List
 
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -19,14 +18,18 @@ class GPSStaticConfig(BaseModel):
     lat: float = 0.0
     lon: float = 0.0
 
-class GPSDynamicConfig(BaseModel):
-    type: Literal['dynamic']
+class GPSSerialConfig(BaseModel):
+    type: Literal['serial']
     serial_device: Path
+
+class GPSCommandConfig(BaseModel):
+    type: Literal['command']
+    command: Annotated[List[str], Field(min_length=1)]
 
 class SaePositionSourceConfig(BaseSettings):
     log_level: LogLevel = LogLevel.WARNING
     redis: RedisConfig = RedisConfig()
-    position_source: Annotated[Union[GPSStaticConfig, GPSDynamicConfig], Field(discriminator='type')]
+    position_source: Annotated[Union[GPSStaticConfig, GPSSerialConfig, GPSCommandConfig], Field(discriminator='type')]
     prometheus_port: Annotated[int, Field(ge=1024, le=65536)] = 8000
 
     model_config = SettingsConfigDict(env_nested_delimiter='__')

--- a/positionsource/datatypes.py
+++ b/positionsource/datatypes.py
@@ -1,0 +1,8 @@
+from typing import NamedTuple
+
+class GpsPosition(NamedTuple):
+    fix: bool
+    lat: float
+    lon: float
+    hdop: float
+    timestamp_utc_ms: int

--- a/positionsource/saepositionsource.py
+++ b/positionsource/saepositionsource.py
@@ -6,8 +6,10 @@ from prometheus_client import Counter, Histogram, Summary
 from visionapi.common_pb2 import MessageType
 from visionapi.sae_pb2 import PositionMessage
 
-from .config import SaePositionSourceConfig, GPSStaticConfig, GPSDynamicConfig
-from .gpsreader import GpsReader
+from .commandreader import CommandGpsReader
+from .config import (GPSCommandConfig, GPSSerialConfig, GPSStaticConfig,
+                     SaePositionSourceConfig)
+from .serialreader import SerialGpsReader
 from .staticreader import StaticReader
 
 logging.basicConfig(format='%(asctime)s %(name)-15s %(levelname)-8s %(processName)-10s %(message)s')
@@ -40,9 +42,12 @@ class SaePositionSource:
         if isinstance(self.config.position_source, GPSStaticConfig):
             logger.debug("Selecting static GPS reader")
             self._gps_reader = StaticReader(self.config.position_source.lat, self.config.position_source.lon)
-        if isinstance(self.config.position_source, GPSDynamicConfig):
+        if isinstance(self.config.position_source, GPSSerialConfig):
             logger.debug("Selecting dynamic GPS reader")
-            self._gps_reader = GpsReader(self.config.position_source.serial_device)
+            self._gps_reader = SerialGpsReader(self.config.position_source.serial_device)
+        if isinstance(self.config.position_source, GPSCommandConfig):
+            logger.debug("Selecting command GPS reader")
+            self._gps_reader = CommandGpsReader(self.config.position_source.command)
     
     @GET_DURATION.time()
     def get(self, timeout=1) -> Optional[PositionMessage]:

--- a/positionsource/serialreader.py
+++ b/positionsource/serialreader.py
@@ -1,23 +1,18 @@
 import time
 from pathlib import Path
 from threading import Event, Lock, Thread
-from typing import NamedTuple, Optional
+from typing import Optional
 
 import serial
 from pynmeagps import NMEAMessage, NMEAReader
 
+from .datatypes import GpsPosition
 
-class GpsDeviceError(Exception):
+
+class SerialGpsError(Exception):
     pass
 
-class GpsPosition(NamedTuple):
-    fix: bool
-    lat: float
-    lon: float
-    hdop: float
-    timestamp_utc_ms: int
-
-class GpsReader:
+class SerialGpsReader:
     '''This class reads GPS data from a serial device and provides the latest position. It uses a separate thread to read data continuously.
         It needs to be closed properly to release the serial port.'''
     def __init__(self, serial_device: Path):
@@ -51,7 +46,7 @@ class GpsReader:
                         self._current_position = new_position
 
         except serial.SerialException as e:
-            raise GpsDeviceError(f"Serial error: {e}")
+            raise SerialGpsError(f"Serial error: {e}")
 
     @property
     def position(self) -> Optional[GpsPosition]:
@@ -66,4 +61,4 @@ class GpsReader:
         self._stop_event.set()
         self._read_thread.join(timeout=2)
         if self._read_thread.is_alive():
-            raise GpsDeviceError('Could not stop reader thread.')
+            raise SerialGpsError('Could not stop reader thread.')

--- a/positionsource/staticreader.py
+++ b/positionsource/staticreader.py
@@ -2,7 +2,7 @@
 import time
 from typing import Optional
 
-from positionsource.gpsreader import GpsPosition
+from .datatypes import GpsPosition
 
 
 class StaticReader:

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -1,10 +1,13 @@
-position_source:
+position_source:                          # static source outputs the same coordinates twice a second
   type: static
   lat: 52
   lon: 10
-# position_source:
+# position_source:                        # dynamic source tries to read NMEA sentences from given serial device (i.e. USB gps receiver)
 #   type: dynamic
 #   serial_device: /dev/ttyACM0
+# position_source:                        # command source tries to read NMEA sentences from stdout of given command
+#   type: command
+#   command: ["gpspipe", "-r"]            # this is passed to Popen; if you want to use a bash pipeline do ["bash", "-c", "command | command2"]
 
 
 log_level: INFO


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request adds support for reading GPS data from an external command.

### New feature: Command-based GPS reader

* Introduced `CommandGpsReader` in `commandreader.py` to read GPS data from the stdout of an arbitrary command, running in a separate thread and parsing NMEA sentences for position updates.
* Added `GPSCommandConfig` to the configuration, allowing users to specify a `command` as a list of strings to be executed for GPS data input.
* Updated the documentation (`README.md`) and the `settings.template.yaml` to explain and provide examples for using the command-based GPS reader.

### Refactoring and type improvements

* Refactored the serial GPS reader: renamed `GpsReader` to `SerialGpsReader`, renamed `GpsDeviceError` to `SerialGpsError`, and moved the `GpsPosition` type to a new `datatypes.py` module for shared use.
* Updated the configuration (`config.py`) to use explicit types for each GPS source (`GPSStaticConfig`, `GPSSerialConfig`, `GPSCommandConfig`), improving clarity and extensibility.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
