### PR TITLE
Remove spike rejection from gps filter (due to the tunnel problem)

### DIFF
--- a/positionsource/config.py
+++ b/positionsource/config.py
@@ -27,7 +27,6 @@ class GPSFilterConfig(BaseModel):
     enabled: Literal[True]
     alpha: Annotated[float, Field(ge=0.0, le=1.0)] = 0.70
     beta: Annotated[float, Field(ge=0.0, le=1.0)] = 0.04
-    spike_radius_m: Annotated[float, Field(ge=0.0)] = 80.0
 
 class GPSFilterConfigDisabled(BaseModel):
     enabled: Literal[False] = False

--- a/positionsource/gps/filter.py
+++ b/positionsource/gps/filter.py
@@ -14,19 +14,16 @@ class GPSFilterState(NamedTuple):
 
 class GPSFilter:
     '''
-    An implementation of an alpha-beta filter for GPS position smoothing with additional spike rejection.
+    An implementation of an alpha-beta filter for GPS position smoothing.
     See: https://en.wikipedia.org/wiki/Alpha_beta_filter
     '''
     def __init__(
         self,
         alpha=0.75,
         beta=0.05,
-        spike_radius_m=80.0,
     ):
         self.alpha = alpha
         self.beta = beta
-
-        self.spike_radius_m = spike_radius_m
 
         self._init_params()
 
@@ -40,7 +37,6 @@ class GPSFilter:
         self.vy = 0.0
 
         self.last_t = None
-        self.stop_timer = 0.0
 
     def reset(self):
         self._init_params()
@@ -80,16 +76,6 @@ class GPSFilter:
         # residual
         rx = x_meas - x_pred
         ry = y_meas - y_pred
-
-        residual_dist = math.hypot(rx, ry)
-
-        # ----------------------------
-        # Spike rejection
-        # ----------------------------
-        if residual_dist > self.spike_radius_m:
-            # ignore impossible jump
-            rx = 0.0
-            ry = 0.0
 
         # ----------------------------
         # Correct location and velocity

--- a/positionsource/saepositionsource.py
+++ b/positionsource/saepositionsource.py
@@ -30,7 +30,7 @@ class SaePositionSource:
         self._previous_position = None
         self._gps_filter = None
         if isinstance(self.config.gps_filter, GPSFilterConfig):
-            self._gps_filter = GPSFilter(alpha=self.config.gps_filter.alpha, beta=self.config.gps_filter.beta, spike_radius_m=self.config.gps_filter.spike_radius_m)
+            self._gps_filter = GPSFilter(alpha=self.config.gps_filter.alpha, beta=self.config.gps_filter.beta)
 
     def __enter__(self):
         self.start()

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -13,7 +13,6 @@ position_source:                          # static source outputs the same coord
 #   enabled: true
 #   alpha: 0.7
 #   beta: 0.04
-#   spike_radius_m: 80
 
 log_level: INFO
 redis:

--- a/tests/gps/test_filter.py
+++ b/tests/gps/test_filter.py
@@ -10,8 +10,8 @@ def _track_iter():
             yield float(ts), float(lat), float(lon)
 
 
-def test_gps_filter():
-    gps_filter = GPSFilter(alpha=0.7, beta=0.04, spike_radius_m=80.0)
+def test_with_track():
+    gps_filter = GPSFilter(alpha=0.7, beta=0.04)
 
     filtered_positions = []
     

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,8 +20,7 @@ def test_full_config():
         "gps_filter": {
             "enabled": true,
             "alpha": 0.8,
-            "beta": 0.05,
-            "spike_radius_m": 100.0
+            "beta": 0.05
         },
         "prometheus_port": 9000
     }''')
@@ -38,7 +37,6 @@ def test_full_config():
     assert config.gps_filter.enabled == True
     assert config.gps_filter.alpha == 0.8
     assert config.gps_filter.beta == 0.05
-    assert config.gps_filter.spike_radius_m == 100.0
     assert config.prometheus_port == 9000
 
 def test_minimal_config_defaults():

--- a/tests/test_saepositionsource.py
+++ b/tests/test_saepositionsource.py
@@ -88,8 +88,36 @@ def test_no_reading(inject_position_readings, config):
 
         assert output is None
 
+def test_intermittent_readings_with_filter(inject_position_readings, config):
+    config.gps_filter = GPSFilterConfig(enabled=True, alpha=0.7, beta=0.04)
+
+    inject_position_readings([
+        GpsPosition(fix=True, lat=52.0, lon=13.0, hdop=1.0, timestamp_utc_ms=1000),
+        GpsPosition(fix=False, lat=52.1, lon=13.1, hdop=1.0, timestamp_utc_ms=2000),
+        GpsPosition(fix=True, lat=52.1, lon=13.1, hdop=1.0, timestamp_utc_ms=3000),
+        GpsPosition(fix=True, lat=52.2, lon=13.2, hdop=1.0, timestamp_utc_ms=4000),
+        GpsPosition(fix=True, lat=52.3, lon=13.3, hdop=1.0, timestamp_utc_ms=5000),
+    ])
+
+    with SaePositionSource(config) as position_source:
+        outputs = [position_source.get() for _ in range(5)]
+
+        assert outputs[0] is not None
+        first_msg = _deserialize(outputs[0])
+        assert first_msg.fix == True
+        assert pytest.approx(first_msg.geo_coordinate.latitude, abs=0.005) == 52.0
+        assert pytest.approx(first_msg.geo_coordinate.longitude, abs=0.005) == 13.0
+        assert first_msg.timestamp_utc_ms == 1000
+
+        assert outputs[-1] is not None
+        last_msg = _deserialize(outputs[-1])
+        assert last_msg.fix == True
+        assert pytest.approx(last_msg.geo_coordinate.latitude, abs=0.05) == 52.3
+        assert pytest.approx(last_msg.geo_coordinate.longitude, abs=0.05) == 13.3
+        assert last_msg.timestamp_utc_ms == 5000
+
 def test_active_filter(inject_position_readings, config):
-    config.gps_filter = GPSFilterConfig(enabled=True, alpha=0.7, beta=0.04, spike_radius_m=100.0)
+    config.gps_filter = GPSFilterConfig(enabled=True, alpha=0.7, beta=0.04)
 
     track = [
         GpsPosition(fix=True, lat=52.40868945371039452, lon=10.780447239674544, hdop=1.0, timestamp_utc_ms=1000),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Remove spike rejection
  - The filter got stuck when entering a tunnel, because the next coordinate would trigger the spike rejection
  - This could be fixed with more logic, but we realistically don't really need it, because most GPS devices should filter out single spikes (according to a lot of data we've seen so far)
- Add test for this error mode

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
